### PR TITLE
Multiple  fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
       env:
         GOROOT: ""
       run: ./gow help
+    - name: Set-up Environment
+      env:
+        GOROOT: ""
+      run: ./gow printenv
   install-old-linux:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +44,10 @@ jobs:
         env:
           GOROOT: ""
         run: ./gow help
+      - name: Set-up Environment
+        env:
+          GOROOT: ""
+        run: ./gow printenv
   no-install-linux:
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +56,8 @@ jobs:
       uses: actions/setup-go@v2.0.3
     - name: Use installed go
       run: ./gow help
+    - name: Set-up Environment
+      run: ./gow printenv
   install-windows:
     runs-on: windows-latest
     steps:
@@ -61,6 +71,11 @@ jobs:
       env:
         GOROOT: ""
       run: "gow.cmd help"
+      shell: cmd
+    - name: Set-up Environment
+      env:
+        GOROOT: ""
+      run: "gow.cmd printenv"
       shell: cmd
   install-old-windows:
     runs-on: windows-latest
@@ -80,6 +95,11 @@ jobs:
           GOROOT: ""
         run: "gow.cmd help"
         shell: cmd
+      - name: Set-up Environment
+        env:
+          GOROOT: ""
+        run: "gow.cmd printenv"
+        shell: cmd
   no-install-windows:
     runs-on: windows-latest
     steps:
@@ -88,4 +108,7 @@ jobs:
       uses: actions/setup-go@v2.0.3
     - name: Use installed go
       run: "gow.cmd help"
+      shell: cmd
+    - name: Set-up Environment
+      run: "gow.cmd printenv"
       shell: cmd

--- a/README.md
+++ b/README.md
@@ -119,3 +119,28 @@ First of all ensure that  the `distributionUrl` matches the OS your are working 
 Ensure that there is not an already avalaible `GOROOT` in your Environment Variables
 
 In case there is a previous Installation with `gow`, manually delete `.go/wrapper/tmp` and `.go/wrapper/go`
+
+#### Set-Up your environment to use `go`
+
+Similar to `docker-machine env` you can set-up your shell to use directly `go` with the configured Environment Variables.
+For that purpose you can use `./gow printenv`
+
+On Windows
+```cmd
+gow printenv
+set GOROOT=C:\Users\elonmusk\go-wrapper\.go\wrapper\go
+set GOPATH=C:\Users\elonmusk\go-wrapper\.go\wrapper\custom-gopath
+set PATH=%GOROOT%\bin;%GOPATH%\bin;%PATH%
+
+# Run this command to configure your shell: copy and paste the above values into your command prompt
+```
+Else
+```bash 
+$ ./gow printenv
+export GOROOT="/home/elonmusk/go-wrapper/.go/wrapper/go"
+export GOPATH="/home/elonmusk/go-wrapper/.go/wrapper/custom-gopath"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+# Run this command to configure your shell:
+# eval "$(./gow printenv)"
+```

--- a/gow
+++ b/gow
@@ -96,7 +96,7 @@ fi
 # This allows using the go-wrapper in projects that prohibit checking in binary data.
 ##########################################################################################
 
-goVersionUrl="https://golang.org/dl/"
+goVersionUrl="https://go.dev/dl/"
 goWrapperPath="$BASE_DIR/.go/wrapper"
 goWrapperProperties="$goWrapperPath/go-wrapper.properties"
 goInstallPath="$goWrapperPath/go"
@@ -221,10 +221,17 @@ if [ -z "$GOROOT" ]; then
     GOROOT="$goInstallPath"
 fi
 
+# Set GOPATH in case there is none 
+if [ -z "$GOPATH" ]; then
+    GOPATH=`$GOROOT/bin/go env GOPATH`
+fi
+
 # For Cygwin, switch paths to Windows format before running go
 if $cygwin; then
   [ -n "$GOROOT" ] &&
     GOROOT=`cygpath --path --windows "$GOROOT"`
+  [ -n "$GOPATH" ] &&
+    GOPATH=`cygpath --path --windows "$GOPATH"`
 fi
 
 # Provide a "standardized" way to retrieve the CLI args that will
@@ -232,4 +239,18 @@ fi
 GO_CMD_LINE_ARGS="$@"
 export GO_CMD_LINE_ARGS
 
-exec "$GOROOT/bin/go" "$@"
+# Export Go Variables for downstream executions
+export GOROOT
+export GOPATH
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+if [ "$1" = "printenv" ]; then 
+  echo "export GOROOT=\"$GOROOT\""
+  echo "export GOPATH=\"$GOPATH\""
+  echo "export PATH=\"\$GOROOT/bin:\$GOPATH/bin:\$PATH\""
+  echo ''
+  echo '# Run this command to configure your shell:'
+  echo '# eval "$(./gow printenv)"'
+else
+  exec "$GOROOT/bin/go" "$@"
+fi

--- a/gow.cmd
+++ b/gow.cmd
@@ -81,7 +81,7 @@ set GO_WRAPPER_PROPERTIES=%GO_PROJECTBASEDIR%\.go\wrapper\go-wrapper.properties
 set GO_INSTALL_PATH=%GO_PROJECTBASEDIR%\.go\wrapper\go
 set GO_TMP_PATH="%GO_PROJECTBASEDIR%\.go\wrapper\tmp"
 set GO_WRAPPER_DATE="%GO_PROJECTBASEDIR%\.go\wrapper\go\go.date"
-set GO_VERSION_URL="https://golang.org/dl/"
+set GO_VERSION_URL="https://go.dev/dl/"
 set GO_VERSION_PATH="%GO_PROJECTBASEDIR%\.go\wrapper\tmp\go.version"
 set GO_ZIP_PATH="%GO_PROJECTBASEDIR%\.go\wrapper\tmp\go.zip"
 
@@ -166,6 +166,11 @@ if "%GOW_VERBOSE%" == "true" (
 )
 
 set GOROOT=%GO_INSTALL_PATH%
+
+@REM Set GOPATH in case there is none 
+if "%GOPATH%" == "" (
+    for /f %%i in ('%GOROOT%\bin\go env GOPATH') do set GOPATH=%%i
+)
 @REM End of extension
 
 @REM Provide a "standardized" way to retrieve the CLI args that will
@@ -173,7 +178,19 @@ set GOROOT=%GO_INSTALL_PATH%
 :run
 set GO_CMD_LINE_ARGS=%*
 
-%GOROOT%\bin\go %*
+@REM Export Go Variables for downstream executions
+set "PATH=%GOROOT%\bin;%GOPATH%\bin;%PATH%"
+
+if "%1" == "printenv" (
+    echo set GOROOT=%GOROOT%
+    echo set GOPATH=%GOPATH%
+    echo set PATH=%%GOROOT%%\bin;%%GOPATH%%\bin;%%PATH%%
+    echo:
+    echo # Run this command to configure your shell: copy and paste the above values into your command prompt
+) else (
+    %GOROOT%\bin\go %*
+)
+
 if ERRORLEVEL 1 goto error
 goto end
 


### PR DESCRIPTION
- The Go Version Retrieval URL has been moved
- Neither the GOROOT nor GOPATH bin was part of the PATH
- The ease to use installed tools (like cobra-cli in your case)

fixes #7 